### PR TITLE
Remove loopback trick by Ribbon client

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>uaa-behind-zuul</artifactId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -50,6 +50,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/api-gateway/src/main/java/com/kakawait/ApiGatewayApplication.java
+++ b/api-gateway/src/main/java/com/kakawait/ApiGatewayApplication.java
@@ -2,8 +2,20 @@ package com.kakawait;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.UserInfoRestTemplateCustomizer;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.netflix.ribbon.RibbonClientHttpRequestFactory;
+import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.client.token.AccessTokenProviderChain;
+import org.springframework.security.oauth2.client.token.grant.client.ClientCredentialsAccessTokenProvider;
+import org.springframework.security.oauth2.client.token.grant.code.AuthorizationCodeAccessTokenProvider;
+import org.springframework.security.oauth2.client.token.grant.implicit.ImplicitAccessTokenProvider;
+import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordAccessTokenProvider;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Thibaud Leprêtre
@@ -15,6 +27,18 @@ public class ApiGatewayApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(ApiGatewayApplication.class, args);
+    }
+
+    @Bean
+    UserInfoRestTemplateCustomizer userInfoRestTemplateCustomizer(SpringClientFactory springClientFactory) {
+        return template -> {
+            AccessTokenProviderChain accessTokenProviderChain = Stream
+                    .of(new AuthorizationCodeAccessTokenProvider(), new ImplicitAccessTokenProvider(),
+                            new ResourceOwnerPasswordAccessTokenProvider(), new ClientCredentialsAccessTokenProvider())
+                    .peek(tp -> tp.setRequestFactory(new RibbonClientHttpRequestFactory(springClientFactory)))
+                    .collect(Collectors.collectingAndThen(Collectors.toList(), AccessTokenProviderChain::new));
+            template.setAccessTokenProvider(accessTokenProviderChain);
+        };
     }
 
 }

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -34,7 +34,7 @@ security:
     sso:
       loginPath: /login
     client:
-      accessTokenUri: http://localhost:${server.port}/uaa/oauth/token
+      accessTokenUri: http://uaa-service/uaa/oauth/token
       userAuthorizationUri: /uaa/oauth/authorize
       clientId: acme
       clientSecret: acmesecret

--- a/dummy-service/pom.xml
+++ b/dummy-service/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>uaa-behind-zuul</artifactId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -46,6 +46,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.kakawait</groupId>
     <artifactId>uaa-behind-zuul</artifactId>
-    <version>0.0.3-SNAPSHOT</version>
+    <version>0.0.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/service-registry/pom.xml
+++ b/service-registry/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>uaa-behind-zuul</artifactId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -38,6 +38,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/uaa-service/pom.xml
+++ b/uaa-service/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.kakawait</groupId>
         <artifactId>uaa-behind-zuul</artifactId>
-        <version>0.0.3-SNAPSHOT</version>
+        <version>0.0.4-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -62,6 +62,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Instead of using loopback trick for `accessTokenUri` like `http://localhost:${server.port}/uaa/oauth/token`, I found a way to enhance `RestTemplate` used to target `accessTokenUri` to add _load balanced_ (`Ribbon`) feature.